### PR TITLE
Add background-size: cover to .jumbotron

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -147,6 +147,7 @@ hr.soften {
 	background-image: url("/img/sunshinephp_header_bg.jpg");
 	background-repeat: no-repeat;
 	background-position: center;
+	background-size: cover;
 }
 .jumbotron h1 {
 	font-size: 80px;


### PR DESCRIPTION
The current jumbotron background image shows unsightly white space on mobile in portrait and on full screen desktop (wider than 1868px). This tweak fixes that.